### PR TITLE
Adjust submodule init instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Compilation
 We use Gradle to handle our dependencies.
 
 1. Checkout project.
-2. Init submodules : git submodule update --init --recursive --depth 1
+2. Init submodules : git submodule update --init --recursive
 3. Setup workspace : gradlew setupCauldron
 4. Build binaries  : gradlew buildPackages
 Note: all binaries will be in distributions folder


### PR DESCRIPTION
The gradlew task createVersionPropertiesFML won't work if the '--depth 1' parameter is passed.